### PR TITLE
Modified the expiration time check when requesting for an existing token

### DIFF
--- a/src/CommerceGuys/Guzzle/Plugin/Oauth2/Oauth2Plugin.php
+++ b/src/CommerceGuys/Guzzle/Plugin/Oauth2/Oauth2Plugin.php
@@ -100,7 +100,7 @@ class Oauth2Plugin implements EventSubscriberInterface
      */
     public function getAccessToken()
     {
-        if (isset($this->accessToken['expires']) && $this->accessToken['expires'] >= time()) {
+        if (isset($this->accessToken['expires']) && $this->accessToken['expires'] < time()) {
             // The access token has expired.
             $this->accessToken = null;
         }


### PR DESCRIPTION
Hi,
Thanks for this plugin. 
It works like a charm, but it always consider a token as expired or maybe I'm doing something wrong.
I think this solves the issue, does this change make sense for you?
Many thanks,
Raul.
