### PR TITLE
Added the redirect_uri paramether when requesting a new token using code...

### DIFF
--- a/src/CommerceGuys/Guzzle/Plugin/Oauth2/GrantType/AuthorizationCode.php
+++ b/src/CommerceGuys/Guzzle/Plugin/Oauth2/GrantType/AuthorizationCode.php
@@ -24,7 +24,7 @@ class AuthorizationCode implements GrantTypeInterface
         $this->config = Collection::fromConfig($config, array(
             'client_secret' => '',
             'scope' => '',
-	    'redirect_uri' => '',
+	    	'redirect_uri' => '',
         ), array(
             'client_id', 'code',
         ));


### PR DESCRIPTION
I think the redirect_uri is missing from the token request (see RFC 6749, 4.1.3)
