### PR TITLE
Bugfix: call getToken of refreshTokenGrantType only if refreshToken exists

### DIFF
--- a/src/Oauth2Subscriber.php
+++ b/src/Oauth2Subscriber.php
@@ -72,11 +72,9 @@ class Oauth2Subscriber implements SubscriberInterface
     {
         $accessToken = null;
 
-        if ($this->refreshTokenGrantType) {
-            // Get an access token using the stored refresh token.
-            if ($this->refreshToken) {
-                $this->refreshTokenGrantType->setRefreshToken($this->refreshToken->getToken());
-            }
+        // Get an access token using the stored refresh token.
+        if ($this->refreshTokenGrantType && $this->refreshToken) {
+            $this->refreshTokenGrantType->setRefreshToken($this->refreshToken->getToken());
             $accessToken = $this->refreshTokenGrantType->getToken();
         }
 


### PR DESCRIPTION
If refreshToken is not set it not should call the method getToken, because it call the server with an empty refreshToken.