### PR TITLE
Send authentication via headers, not in the body

### DIFF
--- a/src/GrantType/GrantTypeBase.php
+++ b/src/GrantType/GrantTypeBase.php
@@ -52,13 +52,18 @@ abstract class GrantTypeBase implements GrantTypeInterface
      */
     public function getToken()
     {
-        $body = $this->config->toArray();
+        $config = $this->config->toArray();
+
+        $body = $config;
         $body['grant_type'] = $this->grantType;
+        unset($body['token_url'], $body['client_id'], $body['client_secret']);
 
-        $access_token_url = $body['token_url'];
-        unset($body['token_url']);
+        $options = [
+          'body' => $body,
+          'auth' => [$config['client_id'], $config['client_secret']],
+        ];
 
-        $response = $this->client->post($access_token_url, ['body' => $body]);
+        $response = $this->client->post($config['token_url'], $options);
         $data = $response->json();
 
         return new AccessToken($data['access_token'], $data['token_type'], $data);

--- a/tests/MockOAuth2Server.php
+++ b/tests/MockOAuth2Server.php
@@ -63,7 +63,7 @@ class MockOAuth2Server
                 return $this->grantTypePassword($requestBody);
 
             case 'client_credentials':
-                return $this->grantTypeClientCredentials($requestBody);
+                return $this->grantTypeClientCredentials($request);
 
             case 'refresh_token':
                 return $this->grantTypeRefreshToken($requestBody);
@@ -111,14 +111,14 @@ class MockOAuth2Server
     }
 
     /**
-     * @param array $requestBody
+     * @param array $request
      *
      * @return array
      *   The response as expected by the MockHandler.
      */
-    protected function grantTypeClientCredentials(array $requestBody)
+    protected function grantTypeClientCredentials(array $request)
     {
-        if ($requestBody['client_secret'] != 'testSecret') {
+        if ($request['client']['auth'][1] != 'testSecret') {
             // @todo correct response headers
             return ['status' => 401];
         }


### PR DESCRIPTION
- [x] There should probably be an option to maintain the old behaviour (nevertheless this should be the new default, as the spec prefers it)