### PR TITLE
Make it possible to get the access token without triggering a refresh

### DIFF
--- a/src/Oauth2Subscriber.php
+++ b/src/Oauth2Subscriber.php
@@ -110,16 +110,18 @@ class Oauth2Subscriber implements SubscriberInterface
     /**
      * Get the access token.
      *
+     * @param bool $refresh Whether to refresh the token, if possible.
+     *
      * @return AccessToken|null Oauth2 access token
      */
-    public function getAccessToken()
+    public function getAccessToken($refresh = true)
     {
         if ($this->accessToken && $this->accessToken->isExpired()) {
             // The access token has expired.
             $this->accessToken = null;
         }
 
-        if (null === $this->accessToken) {
+        if (null === $this->accessToken && $refresh) {
             // Try to acquire a new access token from the server.
             $this->accessToken = $this->acquireAccessToken();
             if ($this->accessToken) {


### PR DESCRIPTION
The use case is to check for the access token at unpredictable times (including in a class destructor) so that it can be stored. Triggering a refresh complicates this.
